### PR TITLE
feat: ステージ選択画面がシーン読み込み時に１秒がかけてフェードインする

### DIFF
--- a/Assets/_SlimeCatch/SelectStage/Scripts/SelectStageManager.cs
+++ b/Assets/_SlimeCatch/SelectStage/Scripts/SelectStageManager.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using _SlimeCatch.Save;
+﻿using _SlimeCatch.Save;
 using _SlimeCatch.Title;
-using Cysharp.Threading.Tasks;
+using DG.Tweening;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -13,10 +12,13 @@ namespace _SlimeCatch.SelectStage
         private bool _isInput;
         [SerializeField] private AudioController audioController; 
         private StageIconView _stageIconView;
+        private CanvasGroup _canvasGroup;
         private ILoadController _loadController;
+        private const float FadeInAnimationTime = 1f;
 
         private void Awake()
         {
+            _canvasGroup = GetComponent<CanvasGroup>();
             _loadController = new SaveLoadController();
             _stageIconView = GetComponent<StageIconView>();
 
@@ -25,7 +27,7 @@ namespace _SlimeCatch.SelectStage
         private async void Start()
         {
             _stageIconView.SetInteractable(_loadController.GetStageClearList());
-            await UniTask.Delay(TimeSpan.FromSeconds(2f));
+            await _canvasGroup.DOFade(1f,FadeInAnimationTime).ToAwaiter();
             _isInput = true;
         }
 

--- a/Assets/_SlimeCatch/SelectStage/SelectStage.unity
+++ b/Assets/_SlimeCatch/SelectStage/SelectStage.unity
@@ -1837,6 +1837,7 @@ GameObject:
   - component: {fileID: 2083933704}
   - component: {fileID: 2083933703}
   - component: {fileID: 2083933705}
+  - component: {fileID: 2083933706}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -1972,3 +1973,15 @@ MonoBehaviour:
   - {fileID: 753825636}
   - {fileID: 76337090}
   - {fileID: 1425241061}
+--- !u!225 &2083933706
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2083933698}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0


### PR DESCRIPTION
# 関連issue

画面 No.15
# 新機能
 * ステージ選択画面へ遷移移動したときにフェードインアニメーションが実行される

![FadeInDemo](https://user-images.githubusercontent.com/41669061/126027002-f7edfd8f-0c22-4748-bdd4-e5589b26b187.gif)


# 機能修正


# 確認事項・確認手順

- [x] `StageSelectシーン` を実行したときにフェードインアニメーションが実行される
- [x] フェードインが終わるまでボタンの入力ができない


# 備考