### PR TITLE
feat: ステージアイコン間の接続アニメーションの実装

### DIFF
--- a/Assets/_SlimeCatch/SelectStage/Scripts/ConnectStageAnimation.cs
+++ b/Assets/_SlimeCatch/SelectStage/Scripts/ConnectStageAnimation.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using DG.Tweening;
+using UniRx;
+using UniRx.Triggers;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace _SlimeCatch.SelectStage
+{
+    public class ConnectStageAnimation : MonoBehaviour
+    {
+        [SerializeField] private List<Image> nextStageImage;
+        [SerializeField] private float connectFadeAnimation = 2f;
+
+
+        private void Start()
+        {
+            //todo デバッグ用
+            this.UpdateAsObservable().Where(_ => Input.GetKeyDown(KeyCode.Alpha6))
+                .Subscribe(_ =>
+                {
+                    SetAnimation(0);
+                }).AddTo(this);
+        }
+
+        public void SetAnimation(int nextStageNo)
+        {
+            nextStageImage[nextStageNo].DOFillAmount(1f, connectFadeAnimation);
+        }
+    }
+}

--- a/Assets/_SlimeCatch/SelectStage/Scripts/ConnectStageAnimation.cs.meta
+++ b/Assets/_SlimeCatch/SelectStage/Scripts/ConnectStageAnimation.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6654f44b24c64760ab8a5cb6da56d53c
+timeCreated: 1627036741

--- a/Assets/_SlimeCatch/SelectStage/SelectStage.unity
+++ b/Assets/_SlimeCatch/SelectStage/SelectStage.unity
@@ -435,12 +435,12 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 35957784b43caae498adf76ff6d59715, type: 3}
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
+  m_FillMethod: 1
+  m_FillAmount: 0
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
@@ -509,12 +509,12 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 35957784b43caae498adf76ff6d59715, type: 3}
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
+  m_FillMethod: 1
+  m_FillAmount: 0
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
@@ -649,12 +649,12 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 35957784b43caae498adf76ff6d59715, type: 3}
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
+  m_FillMethod: 1
+  m_FillAmount: 0
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
@@ -1354,12 +1354,12 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 35957784b43caae498adf76ff6d59715, type: 3}
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
+  m_FillMethod: 1
+  m_FillAmount: 0
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
@@ -1459,6 +1459,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1379031704}
+  - component: {fileID: 1379031705}
   m_Layer: 5
   m_Name: LineToButton
   m_TagString: Untagged
@@ -1490,6 +1491,25 @@ RectTransform:
   m_AnchoredPosition: {x: 42, y: 37}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1379031705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1379031703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6654f44b24c64760ab8a5cb6da56d53c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nextStageImage:
+  - {fileID: 318291368}
+  - {fileID: 1892938368}
+  - {fileID: 1246052831}
+  - {fileID: 461606920}
+  - {fileID: 196824613}
+  connectFadeAnimation: 3
 --- !u!1 &1425241059
 GameObject:
   m_ObjectHideFlags: 0
@@ -1675,12 +1695,12 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 35957784b43caae498adf76ff6d59715, type: 3}
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
+  m_FillMethod: 1
+  m_FillAmount: 0
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
@@ -1981,7 +2001,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2083933698}
   m_Enabled: 1
-  m_Alpha: 0
+  m_Alpha: 1
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0


### PR DESCRIPTION
# 関連issue
No.17

# 新機能
 * ステージ開放時の次のステージにつながるアニメーションの実装

![Demo](https://user-images.githubusercontent.com/41669061/126866890-9285aa3f-9866-4a74-bc3f-e2cbeb8c5621.gif)


# 機能修正


# 確認事項・確認手順

- [ ] ステージ選択画面でキーの６を押す


# 備考