### PR TITLE
feat: ゲームオーバー時に再スタートをする機能の追加

### DIFF
--- a/Assets/_SlimeCatch/Stage/Scripts/PopUp/GameOverPopUp.cs
+++ b/Assets/_SlimeCatch/Stage/Scripts/PopUp/GameOverPopUp.cs
@@ -27,6 +27,8 @@ namespace _SlimeCatch.Stage.PopUp
             {
                 _audioSource.PlayOneShot(retryButtonSe);
                 gameObject.SetActive(false);
+                SceneManager.LoadSceneAsync(SceneManager.GetActiveScene().name);
+
             }).AddTo(this);
 
             backStageSelectButton.OnClickAsObservable().Subscribe(async _ =>


### PR DESCRIPTION
# 関連issue


# 新機能
* ゲームオーバーになったときにゲームオーバーポップの〇ボタンでRetryできる機能の追加
![image](https://user-images.githubusercontent.com/41669061/128528948-66f67cc4-45df-43fe-a9d4-00067b8b268e.png)


# 機能修正


# 確認事項・確認手順

- [ ] 適当なシーンでゲームオーバーになる
- [ ] ゲームオーバーポップアップで〇を押してゲームが再スタートされることを確認


# 備考