### PR TITLE
fix: 子供スライムの武器の当たり判定の修正

### DIFF
--- a/Assets/_SlimeCatch/Stage/Player/Scripts/ChildrenSlimeWeaponCollider.cs
+++ b/Assets/_SlimeCatch/Stage/Player/Scripts/ChildrenSlimeWeaponCollider.cs
@@ -17,10 +17,12 @@ namespace _SlimeCatch.Player
 
         public async void OnCollisionEnter2D(Collision2D other)
         {
-            if (!other.gameObject.CompareTag("Weapon")) return;
-            _slimesReceiveSe.ReceiveSe();
-            await UniTask.Delay(TimeSpan.FromSeconds(1f));
-            IsAttack.Value = true;
+            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") || other.gameObject.CompareTag("Weapon/OtherWeapon"))
+            {
+                _slimesReceiveSe.ReceiveSe();
+                await UniTask.Delay(TimeSpan.FromSeconds(1f));
+                IsAttack.Value = true;
+            }
         }
     }
     


### PR DESCRIPTION
# 関連issue


# 新機能
 

# 機能修正
* 子供スライムの武器に当たり判定の修正

# 確認事項・確認手順

- [ ] 任意のシーンで子供スライムに武器が当たって，ダメージを受けることを確認


# 備考