### PR TITLE
feature ステージ解放アニメーションの作成

### DIFF
--- a/Assets/_SlimeCatch/SelectStage/Scripts/AnimationManager.cs
+++ b/Assets/_SlimeCatch/SelectStage/Scripts/AnimationManager.cs
@@ -1,0 +1,91 @@
+﻿using BayatGames.SaveGameFree;
+using DG.Tweening;
+using System.Linq;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace _SlimeCatch.SelectStage
+{
+    public class AnimationManager : MonoBehaviour
+    {
+        //アイコンオブジェクト格納（座標取得用）
+        public GameObject iconOne;
+        public GameObject iconTwo;
+        public GameObject iconThree;
+        public GameObject iconFour;
+        public GameObject iconFive;
+        public GameObject iconSix;
+
+        private string stageName; //前シーンのステージ名
+        private int stageNumber; //前シーンのステージ名から抽出した数字
+        private bool playFlg; //アニメーションを再生したかの判別
+        public GameObject openAnimeImage; //アニメーション用画像
+        void Start()
+        {
+            stageName = PlayerPrefs.GetString("SceneName", ""); //クリアしたステージ名をPlayerPrefsから取得
+            openAnimeImage.SetActive(false);
+            if (stageName == "Title" || stageName == "")
+            {
+                stageName = "none";
+                Debug.Log("クリアしたステージはありません");
+            }
+            else
+            {
+                stageNumber = int.Parse(Regex.Replace(stageName, @"[^0-9]", "")); //ステージ名から数字を抽出
+                //クリアフラグ呼び出し第一引数のキー登録が無ければ第二引数が返る
+                playFlg = SettingPrefs.GetBool($"{stageName}", false);
+                AnimePlay();
+            }
+
+            Debug.Log("StageName : " + stageName + " StageNumber : " + stageNumber);
+            Debug.Log(playFlg);
+        }
+        void AnimePlay()
+        {
+            if (!playFlg)
+            {
+                if (stageName == "Stage1")
+                {
+                    openAnimeImage.transform.position = iconTwo.transform.position;
+                }
+                if (stageName == "Stage2")
+                {
+                    openAnimeImage.transform.position = iconThree.transform.position;
+                }
+                if (stageName == "Stage3")
+                {
+                    openAnimeImage.transform.position = iconFour.transform.position;
+                }
+                if (stageName == "Stage4")
+                {
+                    openAnimeImage.transform.position = iconFive.transform.position;
+                }
+                if (stageName == "Stage5")
+                {
+                    openAnimeImage.transform.position = iconSix.transform.position;
+                }
+
+                openAnimeImage.SetActive(true);
+                //アニメーション
+                var sequence = DOTween.Sequence();
+                sequence.Append(
+                    openAnimeImage.transform.DOMoveY(openAnimeImage.transform.position.y + 100, 3f)
+                    );
+                sequence.Join(
+                    openAnimeImage.transform.DOScale(new Vector3(1f, 1f), 3f)
+                    );
+
+                var image = openAnimeImage.GetComponent<Image>();
+                DOTween.ToAlpha(
+                    () => image.color,
+                    color => image.color = color,
+                    1f,
+                    5f
+                );
+                //アニメーションここまで
+                SettingPrefs.SetBool($"{stageName}", true);
+            }
+        }
+    }
+}

--- a/Assets/_SlimeCatch/SelectStage/Scripts/AnimationManager.cs.meta
+++ b/Assets/_SlimeCatch/SelectStage/Scripts/AnimationManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 646502d4e3cfd224c8629d8988772445
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_SlimeCatch/SelectStage/Scripts/SettingPrefs.cs
+++ b/Assets/_SlimeCatch/SelectStage/Scripts/SettingPrefs.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SettingPrefs : MonoBehaviour
+{
+    public static bool GetBool(string key, bool defalutValue)
+    {
+        var value = PlayerPrefs.GetInt(key, defalutValue ? 1 : 0);
+        return value == 1;
+    }
+
+    public static void SetBool(string key, bool value)
+    {
+        PlayerPrefs.SetInt(key, value ? 1 : 0);
+    }
+}

--- a/Assets/_SlimeCatch/SelectStage/Scripts/SettingPrefs.cs.meta
+++ b/Assets/_SlimeCatch/SelectStage/Scripts/SettingPrefs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e3305fe37298b6468d76ba2d47c398c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_SlimeCatch/SelectStage/SelectStage.unity
+++ b/Assets/_SlimeCatch/SelectStage/SelectStage.unity
@@ -527,6 +527,56 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 318291366}
   m_CullTransparentMesh: 0
+--- !u!1 &345570747
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 345570749}
+  - component: {fileID: 345570748}
+  m_Layer: 0
+  m_Name: AnimationManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &345570748
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 345570747}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 646502d4e3cfd224c8629d8988772445, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  iconOne: {fileID: 110499386}
+  iconTwo: {fileID: 939039451}
+  iconThree: {fileID: 2080444791}
+  iconFour: {fileID: 753825634}
+  iconFive: {fileID: 76337088}
+  iconSix: {fileID: 1425241059}
+  openAnimeImage: {fileID: 995550310}
+--- !u!4 &345570749
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 345570747}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &425641989
 GameObject:
   m_ObjectHideFlags: 0
@@ -1298,6 +1348,80 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 939039451}
   m_CullTransparentMesh: 0
+--- !u!1 &995550310
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 995550313}
+  - component: {fileID: 995550312}
+  - component: {fileID: 995550311}
+  m_Layer: 5
+  m_Name: Star
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &995550311
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 995550310}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: e11691b559ef80147a7fbb14c3325b48, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &995550312
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 995550310}
+  m_CullTransparentMesh: 0
+--- !u!224 &995550313
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 995550310}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2083933702}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1246052829
 GameObject:
   m_ObjectHideFlags: 0
@@ -1925,6 +2049,7 @@ RectTransform:
   - {fileID: 753825635}
   - {fileID: 76337089}
   - {fileID: 1425241060}
+  - {fileID: 995550313}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/_SlimeCatch/Stage/Scripts/PopUp/GameClearPopUp.cs
+++ b/Assets/_SlimeCatch/Stage/Scripts/PopUp/GameClearPopUp.cs
@@ -27,6 +27,7 @@ namespace _SlimeCatch.Stage.PopUp
             _audioSource.PlayOneShot(gameClearSe);
             gameObject.SetActive(true);
             SetNextStageInfo(stageEnum);
+            PlayerPrefs.SetString("SceneName", SceneManager.GetActiveScene().name); //PlayerPrefsに現在のシーンを保存
             //todo シーン遷移の時間を調節する
             await UniTask.Delay(TimeSpan.FromSeconds(3f));
             SceneManager.LoadSceneAsync("_SlimeCatch/SelectStage/SelectStage");


### PR DESCRIPTION
# 関連issue

# 新機能
* ステージをクリアするとステージセレクト画面でアニメーションが再生される機能の追加

# 機能修正

# 確認事項・確認手順
- [ ] シーン"SelectStage"で確認
- [ ] ゲームオブジェクト"AnimationManager"が存在している
- [ ] "AnimationManager"インスペクター上で各ステージのボタン・星の画像が選択されている
- [ ] ステージの初回クリア後、セレクト画面に戻った際にアニメーションが再生される。
- [ ] 二回目のクリア時は、セレクト画面に戻ってもアニメーションが再生されない。

# 備考
* PlayerPrefsに情報を格納しているので、動作の再確認をする場合はUnityEditor上のEdit->Clear All PlayerPrefsで削除できます。WebGLにも対応していますのでビルド後も問題なく動作するはずです。
* 現状はシンプルなアニメーションが再生されていますが、改善できないか検討します。