### PR TITLE
沼デバフ中に槍が子スライムに刺さると沼デバフのタイマーをリセットする機能

### DIFF
--- a/Assets/_SlimeCatch/Stage/Player/Scripts/ChildSinkDeath.cs
+++ b/Assets/_SlimeCatch/Stage/Player/Scripts/ChildSinkDeath.cs
@@ -1,12 +1,27 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using _SlimeCatch.Stage.Gimmick.Wetland.Scripts;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 
 public class ChildSinkDeath : MonoBehaviour
 {
-    public async void SinkDeath()
+    private CancellationTokenSource hoge = null;
+
+
+    public async Task CancelToken()
     {
-        await UniTask.Delay(TimeSpan.FromSeconds(15f));
+        hoge.Cancel();
+        GetComponent<ChildAnimationHandler>().ChildFloat();
+    }
+
+    public async UniTask SinkDeath()
+    {
+        hoge = new CancellationTokenSource();
+
+        await UniTask.Delay(TimeSpan.FromSeconds(15f), cancellationToken: hoge.Token);
+
         this.gameObject.SetActive(false);
     }
 }

--- a/Assets/_SlimeCatch/Stage/Player/Scripts/ChildrenSlimeWeaponCollider.cs
+++ b/Assets/_SlimeCatch/Stage/Player/Scripts/ChildrenSlimeWeaponCollider.cs
@@ -20,7 +20,7 @@ namespace _SlimeCatch.Player
         public async void OnCollisionEnter2D(Collision2D other)
         {
             if (other.gameObject.CompareTag("Weapon/MolotovCocktail") ||
-                other.gameObject.CompareTag("Weapon/OtherWeapon"))
+                other.gameObject.CompareTag("Weapon/OtherWeapon") || other.gameObject.CompareTag("Weapon/Spear"))
             {
                 if (other.gameObject.CompareTag("Weapon/MolotovCocktail"))
                 {
@@ -32,11 +32,11 @@ namespace _SlimeCatch.Player
                     _slimesReceiveSe.ReceiveSe();
                 }
 
-                if (other.gameObject.CompareTag("Weapon/Arrow"))
+                if (other.gameObject.CompareTag("Weapon/Spear"))
                 {
                     if (SceneManager.GetActiveScene().name == "Stage5")
                     {
-                        GetComponent<ChildSinkDeath>().CancelToken();
+                        await GetComponent<ChildSinkDeath>().CancelToken();
                         return;
                     }
                 }

--- a/Assets/_SlimeCatch/Stage/Player/Scripts/ChildrenSlimeWeaponCollider.cs
+++ b/Assets/_SlimeCatch/Stage/Player/Scripts/ChildrenSlimeWeaponCollider.cs
@@ -3,6 +3,7 @@ using _SlimeCatch.Player;
 using Cysharp.Threading.Tasks;
 using UniRx;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace _SlimeCatch.Player
 {
@@ -18,19 +19,32 @@ namespace _SlimeCatch.Player
 
         public async void OnCollisionEnter2D(Collision2D other)
         {
-            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") || other.gameObject.CompareTag("Weapon/OtherWeapon"))
+            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") ||
+                other.gameObject.CompareTag("Weapon/OtherWeapon"))
             {
                 if (other.gameObject.CompareTag("Weapon/MolotovCocktail"))
                 {
                     _slimesReceiveSe.MolotovCocktailSe();
                 }
+
                 if (other.gameObject.CompareTag("Weapon/OtherWeapon"))
                 {
                     _slimesReceiveSe.ReceiveSe();
                 }
+
+                if (other.gameObject.CompareTag("Weapon/Arrow"))
+                {
+                    if (SceneManager.GetActiveScene().name == "Stage5")
+                    {
+                        GetComponent<ChildSinkDeath>().CancelToken();
+                        return;
+                    }
+                }
+
                 await UniTask.Delay(TimeSpan.FromSeconds(1f));
                 IsAttack.Value = true;
             }
+
             if (other.gameObject.CompareTag("Weapon/WaterBalloon"))
             {
                 _slimesReceiveSe.WaterBalloonSe();

--- a/Assets/_SlimeCatch/Stage/Player/Scripts/ParentSlimeWeaponCollider.cs
+++ b/Assets/_SlimeCatch/Stage/Player/Scripts/ParentSlimeWeaponCollider.cs
@@ -10,15 +10,21 @@ namespace _SlimeCatch.Player
             {
                 GetComponent<SlimesReceiveSE>().MolotovCocktailSe();
             }
-            if (other.gameObject.CompareTag("Weapon/OtherWeapon"))
+
+            if (other.gameObject.CompareTag("Weapon/OtherWeapon") || other.gameObject.CompareTag("Weapon/Spear"))
             {
                 GetComponent<SlimesReceiveSE>().ReceiveSe();
             }
+
             if (other.gameObject.CompareTag("Weapon/WaterBalloon"))
             {
                 GetComponent<SlimesReceiveSE>().WaterBalloonSe();
             }
-            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") || other.gameObject.CompareTag("Weapon/WaterBalloon") || other.gameObject.CompareTag("Weapon/OtherWeapon")|| other.gameObject.CompareTag("Gimmick"))
+
+            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") ||
+                other.gameObject.CompareTag("Weapon/WaterBalloon") ||
+                other.gameObject.CompareTag("Weapon/OtherWeapon") || other.gameObject.CompareTag("Weapon/Spear") ||
+                other.gameObject.CompareTag("Gimmick"))
             {
                 Destroy(other.gameObject);
             }

--- a/Assets/_SlimeCatch/Stage/Weapon/Prefabs/Spear.prefab
+++ b/Assets/_SlimeCatch/Stage/Weapon/Prefabs/Spear.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: -7626759215819588956}
   m_Layer: 0
   m_Name: Spear
-  m_TagString: Weapon/OtherWeapon
+  m_TagString: Weapon/Spear
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -10,6 +10,7 @@ TagManager:
   - Weapon
   - Weapon/WaterBalloon
   - Gimmick
+  - Weapon/Spear
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
# 関連issue


# 新機能
* 沼デバフ中に槍が子スライムに刺さると沼デバフのタイマーをリセットする機能

# 機能修正


# 確認事項・確認手順

- [ ] ステージ5にて確認できます
- [ ] ArrowのタグをWeapon/Spearに一時的に変更して確認するのが一番楽かもしれません



# 備考