### PR TITLE
fix ゲームクリア画面が出ない問題修正・水風船のコライダー調整・ビューマネージャー再インポート

### DIFF
--- a/Assets/_SlimeCatch/Stage/Prefabs/ViewManager.prefab
+++ b/Assets/_SlimeCatch/Stage/Prefabs/ViewManager.prefab
@@ -1,0 +1,54 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7669076683141448409
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7669076683141448408}
+  - component: {fileID: 7669076683141448415}
+  m_Layer: 0
+  m_Name: ViewManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7669076683141448408
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7669076683141448409}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7669076683141448415
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7669076683141448409}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ff0a1d78c234a0685718adfabeb9012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
+  backGround: {fileID: 0}
+  childList:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}

--- a/Assets/_SlimeCatch/Stage/Prefabs/ViewManager.prefab.meta
+++ b/Assets/_SlimeCatch/Stage/Prefabs/ViewManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c08020df18da48a43b0acd53a28e5027
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_SlimeCatch/Stage/Scripts/PopUp/GameClearPopUp.cs
+++ b/Assets/_SlimeCatch/Stage/Scripts/PopUp/GameClearPopUp.cs
@@ -24,8 +24,8 @@ namespace _SlimeCatch.Stage.PopUp
 
         public async void SetView(StageEnum stageEnum)
         {
-            _audioSource.PlayOneShot(gameClearSe);
             gameObject.SetActive(true);
+            _audioSource.PlayOneShot(gameClearSe);
             SetNextStageInfo(stageEnum);
             //todo シーン遷移の時間を調節する
             await UniTask.Delay(TimeSpan.FromSeconds(3f));

--- a/Assets/_SlimeCatch/Stage/Weapon/Prefabs/Water Baloon.prefab
+++ b/Assets/_SlimeCatch/Stage/Weapon/Prefabs/Water Baloon.prefab
@@ -98,7 +98,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.069197655, y: 0.06919479}
+  m_Offset: {x: -0.02474904, y: 0.013634205}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -109,7 +109,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2.2777863, y: 3.7724075}
+  m_Size: {x: 0.67763567, y: 1.1277142}
   m_EdgeRadius: 0
 --- !u!50 &2605386983144729478
 Rigidbody2D:


### PR DESCRIPTION
# 関連issue

# 新機能

# 機能修正
* ゲームクリア画面が出ない問題修正。
* 水風船の当たり判定を調整
* ビューマネージャーを再インポート

# 確認事項・確認手順
- [ ] ビューマネージャーがプレハブ内に存在すること
- [ ] ゲームクリア画面が出ること
- [ ] 水風船プレハブの当たり判定が水風船の大きさと同じくらいになっていること

# 備考