### PR TITLE
セーブ機能の追加

### DIFF
--- a/Assets/_SlimeCatch/SelectStage/Scripts/SelectStageManager.cs
+++ b/Assets/_SlimeCatch/SelectStage/Scripts/SelectStageManager.cs
@@ -1,6 +1,8 @@
-﻿using _SlimeCatch.Save;
+﻿using System.Collections.Generic;
+using _SlimeCatch.Save;
 using _SlimeCatch.Title;
 using DG.Tweening;
+using NaughtyAttributes;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -16,17 +18,25 @@ namespace _SlimeCatch.SelectStage
         private ILoadController _loadController;
         private const float AnimationTime = 1f;
 
+        [Button("クリアデータ初期化")]
+        private void ClearSaveData()
+        {
+            for (var index = 1; index <= 6; index++)
+            {
+                SettingPrefs.SetBool($"Stage{index}",false);
+            }
+        }
+
         private void Awake()
         {
             _canvasGroup = GetComponent<CanvasGroup>();
             _loadController = new SaveLoadController();
             _stageIconView = GetComponent<StageIconView>();
-
         }
 
         private async void Start()
         {
-            _stageIconView.SetInteractable(_loadController.GetStageClearList());
+            _stageIconView.SetInteractable(GetStageOpenData());
             await _canvasGroup.DOFade(1f,AnimationTime).ToAwaiter();
             _isInput = true;
         }
@@ -84,6 +94,17 @@ namespace _SlimeCatch.SelectStage
             audioController.ClickOnPlaySe();
             await _canvasGroup.DOFade(0f,AnimationTime).ToAwaiter();
             SceneManager.LoadSceneAsync($"stage{stageNo}");
+        }
+
+        private static IEnumerable<bool> GetStageOpenData()
+        {
+            var saveList = new List<bool>();
+            for (var index = 1; index <= 6; index++)
+            {
+                saveList.Add(SettingPrefs.IsClearStage($"Stage{index}"));
+            }
+
+            return saveList;
         }
 
     }

--- a/Assets/_SlimeCatch/SelectStage/Scripts/SettingPrefs.cs
+++ b/Assets/_SlimeCatch/SelectStage/Scripts/SettingPrefs.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 public class SettingPrefs : MonoBehaviour
 {
@@ -8,6 +6,12 @@ public class SettingPrefs : MonoBehaviour
     {
         var value = PlayerPrefs.GetInt(key, defalutValue ? 1 : 0);
         return value == 1;
+    }
+
+    public static bool IsClearStage(string stageName)
+    {
+        var value = PlayerPrefs.GetInt(stageName);
+        return value != 0;
     }
 
     public static void SetBool(string key, bool value)

--- a/Assets/_SlimeCatch/Stage/Scripts/PopUp/GameClearPopUp.cs
+++ b/Assets/_SlimeCatch/Stage/Scripts/PopUp/GameClearPopUp.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using _SlimeCatch.Wave;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -26,12 +27,14 @@ namespace _SlimeCatch.Stage.PopUp
         {
             gameObject.SetActive(true);
             _audioSource.PlayOneShot(gameClearSe);
-            if (!_SlimeCatch.SelectStage.AnimationManager.playFlg)
+            if (!SelectStage.AnimationManager.playFlg)
             {
                 SetNextStageInfo(stageEnum);
             }
-            //SetNextStageInfo(stageEnum);
             PlayerPrefs.SetString("SceneName", SceneManager.GetActiveScene().name);
+            var stageNumber = int.Parse(Regex.Replace(SceneManager.GetActiveScene().name, @"[^0-9]", ""));
+            var nextStageIndex = stageNumber + 1;
+            SettingPrefs.SetBool($"Stage{nextStageIndex}",true);
             //todo シーン遷移の時間を調節する
             await UniTask.Delay(TimeSpan.FromSeconds(3f));
             SceneManager.LoadSceneAsync("_SlimeCatch/SelectStage/SelectStage");

--- a/Assets/_SlimeCatch/Title/Scripts/SceneController.cs
+++ b/Assets/_SlimeCatch/Title/Scripts/SceneController.cs
@@ -30,5 +30,18 @@ namespace _SlimeCatch.Title
                     SceneManager.LoadSceneAsync("SelectStage");
                 }).AddTo(this);
         }
+
+        private void SetInitStageOpenInfo()
+        {
+            if (!PlayerPrefs.HasKey("FirstGame"))
+            {
+                for (var index = 2; index <= 6; index++)
+                {
+                    SettingPrefs.SetBool($"Stage{index}",false);
+                }
+                SettingPrefs.SetBool("FirstGame",true);
+                
+            }
+        }
     }
 }


### PR DESCRIPTION
# 関連issue


# 新機能
* 各ステージの解放データをローカルキャッシュに保存
* 初めてのプレイの場合，ステージ１以外のステージの解放ステータスをOFFに変更

# 機能修正


# 確認事項・確認手順

- [ ] ステージをクリアしたときに次のステージが解放されている
- [ ] 初めてのプレイの場合，ステージ１のみ解放されている(同ブラウザのみ)


# 備考