### PR TITLE
#22のプルリクを再度上げ、スライムが一体ずつ死ぬようにした

### DIFF
--- a/Assets/_SlimeCatch/Stage/Player/Scripts/ChildSinkDeath.cs
+++ b/Assets/_SlimeCatch/Stage/Player/Scripts/ChildSinkDeath.cs
@@ -1,12 +1,27 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using _SlimeCatch.Stage.Gimmick.Wetland.Scripts;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
+using static Cysharp.Threading.Tasks.UniTask;
 
 public class ChildSinkDeath : MonoBehaviour
 {
-    public async void SinkDeath()
+    private CancellationTokenSource _hoge = null;
+
+
+    public async Task CancelToken()
     {
-        await UniTask.Delay(TimeSpan.FromSeconds(15f));
+        _hoge.Cancel();
+        GetComponent<ChildAnimationHandler>().ChildFloat();
+    }
+
+    public async UniTask SinkDeath()
+    {
+        _hoge = new CancellationTokenSource();
+
+        await Delay(TimeSpan.FromSeconds(15f), cancellationToken: _hoge.Token);
         this.gameObject.SetActive(false);
     }
 }

--- a/Assets/_SlimeCatch/Stage/Player/Scripts/ChildrenSlimeWeaponCollider.cs
+++ b/Assets/_SlimeCatch/Stage/Player/Scripts/ChildrenSlimeWeaponCollider.cs
@@ -33,8 +33,21 @@ namespace _SlimeCatch.Player
                     }
                 }
 
-                await UniTask.Delay(TimeSpan.FromSeconds(1f));
-                IsAttack.Value = true;
+                if (other.gameObject.CompareTag("Weapon/MolotovCocktail"))
+                {
+                    Destroy(other.gameObject);
+                    await UniTask.Delay(TimeSpan.FromSeconds(1f));
+
+                    IsAttack.Value = true;
+                }
+
+                if (other.gameObject.CompareTag("Weapon/OtherWeapon"))
+                {
+                    Destroy(other.gameObject);
+                    await UniTask.Delay(TimeSpan.FromSeconds(1f));
+
+                    this.gameObject.SetActive(false);
+                }
             }
         }
     }

--- a/Assets/_SlimeCatch/Stage/Player/Scripts/ChildrenSlimeWeaponCollider.cs
+++ b/Assets/_SlimeCatch/Stage/Player/Scripts/ChildrenSlimeWeaponCollider.cs
@@ -3,6 +3,8 @@ using _SlimeCatch.Player;
 using Cysharp.Threading.Tasks;
 using UniRx;
 using UnityEngine;
+using UnityEngine.SceneManagement;
+
 
 namespace _SlimeCatch.Player
 {
@@ -18,9 +20,19 @@ namespace _SlimeCatch.Player
 
         public async void OnCollisionEnter2D(Collision2D other)
         {
-            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") || other.gameObject.CompareTag("Weapon/OtherWeapon"))
+            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") ||
+                other.gameObject.CompareTag("Weapon/OtherWeapon") || other.gameObject.CompareTag("Weapon/Spear"))
             {
                 _slimesReceiveSe.ReceiveSe();
+                if (other.gameObject.CompareTag("Weapon/Spear"))
+                {
+                    if (SceneManager.GetActiveScene().name == "Stage5")
+                    {
+                        await GetComponent<ChildSinkDeath>().CancelToken();
+                        return;
+                    }
+                }
+
                 await UniTask.Delay(TimeSpan.FromSeconds(1f));
                 IsAttack.Value = true;
             }

--- a/Assets/_SlimeCatch/Stage/Player/Scripts/ParentSlimeWeaponCollider.cs
+++ b/Assets/_SlimeCatch/Stage/Player/Scripts/ParentSlimeWeaponCollider.cs
@@ -6,11 +6,15 @@ namespace _SlimeCatch.Player
     {
         private void OnCollisionEnter2D(Collision2D other)
         {
-            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") || other.gameObject.CompareTag("Weapon/OtherWeapon"))
+            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") ||
+                other.gameObject.CompareTag("Weapon/OtherWeapon") || other.gameObject.CompareTag("Weapon/Spear"))
             {
                 GetComponent<SlimesReceiveSE>().ReceiveSe();
             }
-            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") || other.gameObject.CompareTag("Weapon/OtherWeapon")|| other.gameObject.CompareTag("Gimmick"))
+
+            if (other.gameObject.CompareTag("Weapon/MolotovCocktail") ||
+                other.gameObject.CompareTag("Weapon/OtherWeapon") || other.gameObject.CompareTag("Gimmick") ||
+                other.gameObject.CompareTag("Weapon/Spear"))
             {
                 Destroy(other.gameObject);
             }

--- a/Assets/_SlimeCatch/Stage/Weapon/Prefabs/Arrow.prefab
+++ b/Assets/_SlimeCatch/Stage/Weapon/Prefabs/Arrow.prefab
@@ -98,7 +98,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.060958505, y: 0.16625094}
+  m_Offset: {x: -0.0003387928, y: 0.03398919}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -109,7 +109,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2.3685815, y: 4.647498}
+  m_Size: {x: 0.505898, y: 0.85599804}
   m_EdgeRadius: 0
 --- !u!50 &7246124004146789672
 Rigidbody2D:

--- a/Assets/_SlimeCatch/Stage/Weapon/Prefabs/Spear.prefab
+++ b/Assets/_SlimeCatch/Stage/Weapon/Prefabs/Spear.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: -7626759215819588956}
   m_Layer: 0
   m_Name: Spear
-  m_TagString: Weapon/OtherWeapon
+  m_TagString: Weapon/Spear
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/_SlimeCatch/Stage/Weapon/Prefabs/Sword.prefab
+++ b/Assets/_SlimeCatch/Stage/Weapon/Prefabs/Sword.prefab
@@ -119,7 +119,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.22737312, y: 0.0454731}
+  m_Offset: {x: 0.022637367, y: 0.019153595}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -130,7 +130,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 4.2661095, y: 13.83575}
+  m_Size: {x: 0.9614353, y: 2.1388655}
   m_EdgeRadius: 0
 --- !u!114 &-1510543151943322300
 MonoBehaviour:

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -8,6 +8,7 @@ TagManager:
   - Gimmick
   - Weapon/MolotovCocktail
   - Weapon/OtherWeapon
+  - Weapon/Spear
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
# 関連issue


# 新機能
* #22のプルリクを再度上げ、スライムが一体ずつ死ぬようにした

# 機能修正


# 確認事項・確認手順

- [ ] ステージ５にて浮き沈みの確認
- [ ]武器コライダーの修正、スライムに当たった後すぐに破壊されるようにした(SEは鳴ります)


# 備考